### PR TITLE
Updated documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The use of `parseUsingOnlyTrustedCerts` guarantees that the signature in PKCS#7 
 
 ## Documentation
 
-Check out the documentation for the library [here](./docs/).
+Check out the documentation for the library [here](https://protonmail.github.io/ios-receipt-parser/docs/).
 
 ## Contributing
 


### PR DESCRIPTION
Documentation link in the README replaced with the Github Pages URL.